### PR TITLE
fix(types): TS7016: Could not find a declaration file for module react-native-pdf-from-image.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",
   "module": "./lib/module/index.js",
+  "types": "./lib/typescript/module/src/index.d.ts",
   "exports": {
     ".": {
       "import": {


### PR DESCRIPTION
Hello, thank you for the library!

I’m using Expo 52, and when I added this library, I encountered the following error.

![ts-error-pdf](https://github.com/user-attachments/assets/943ffb35-c1ae-4ba1-85f2-7be62a4e3b48)

If I specify the types property, the error goes away.